### PR TITLE
Add suppport for custom Azure Tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,23 @@
 resource "azurerm_resource_group" "aci_rg" {
   name     = "${var.resource_group_name}"
   location = "${var.location}"
+  tags     = var.tags
 }
 
 resource "azurerm_container_group" "containergroup" {
-  name                  = "${var.container_group_name}"
-  resource_group_name   = "${azurerm_resource_group.aci_rg.name}"
-  location              = "${azurerm_resource_group.aci_rg.location}"
-  ip_address_type       = "public"
-  dns_name_label        = "${var.dns_name_label}"
-  os_type               = "${var.os_type}"
+  name                = "${var.container_group_name}"
+  resource_group_name = "${azurerm_resource_group.aci_rg.name}"
+  location            = "${azurerm_resource_group.aci_rg.location}"
+  ip_address_type     = "public"
+  dns_name_label      = "${var.dns_name_label}"
+  os_type             = "${var.os_type}"
+  tags                = var.tags
 
   container {
-      name      = "${var.container_name}"
-      image     = "${var.image_name}"
-      cpu       = "${var.cpu_core_number}"
-      memory    = "${var.memory_size}"
-      port      = "${var.port_number}"
+    name   = "${var.container_name}"
+    image  = "${var.image_name}"
+    cpu    = "${var.cpu_core_number}"
+    memory = "${var.memory_size}"
+    port   = "${var.port_number}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,46 +1,52 @@
 variable "container_group_name" {
-  default       = "myContGroup"
-  description   = "The name of the container group"
+  default     = "myContGroup"
+  description = "The name of the container group"
 }
 
 variable "resource_group_name" {
-  default       = "MyContGroup-RG01"
-  description   = "The name of the resource group"
+  default     = "MyContGroup-RG01"
+  description = "The name of the resource group"
 }
 
 variable "location" {
-  default       = "westus"  
-  description   = "Azure location"
+  default     = "westus"
+  description = "Azure location"
 }
 
 variable "dns_name_label" {
-  description   = "The DNS label/name for the container groups IP"
+  description = "The DNS label/name for the container groups IP"
 }
 
 variable "os_type" {
-  description   = "The OS for the container group. Allowed values are Linux and Windows"
+  description = "The OS for the container group. Allowed values are Linux and Windows"
 }
 
 variable "container_name" {
-  default       = "mycont01"  
-  description   = "The name of the container"
+  default     = "mycont01"
+  description = "The name of the container"
 }
 
 variable "image_name" {
-  description   = "The container image name"
+  description = "The container image name"
 }
 
 variable "cpu_core_number" {
-  default       = "0.5"  
-  description   = "The required number of CPU cores of the containers"
+  default     = "0.5"
+  description = "The required number of CPU cores of the containers"
 }
 
 variable "memory_size" {
-  default       = "1.5"  
-  description   = "The required memory of the containers in GB"
+  default     = "1.5"
+  description = "The required memory of the containers in GB"
 }
 
 variable "port_number" {
-  default       = "80"  
-  description   = "A public port for the container"
+  default     = "80"
+  description = "A public port for the container"
+}
+
+variable "tags" {
+  type        = map
+  default     = {}
+  description = "Tags associated with each Azure resource"
 }


### PR DESCRIPTION
Consumers can specify tags using the `tags` variable. Those will be set on both, the Resource Group and the Container Group