### PR TITLE
Fix and update broken ACI module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,21 @@
 resource "azurerm_resource_group" "aci_rg" {
-  name     = "${var.resource_group_name}"
-  location = "${var.location}"
+  name     = var.resource_group_name
+  location = var.location
 }
 
 resource "azurerm_container_group" "containergroup" {
-  name                  = "${var.container_group_name}"
-  resource_group_name   = "${azurerm_resource_group.aci_rg.name}"
-  location              = "${azurerm_resource_group.aci_rg.location}"
-  ip_address_type       = "public"
-  dns_name_label        = "${var.dns_name_label}"
-  os_type               = "${var.os_type}"
+  name                = var.container_group_name
+  resource_group_name = azurerm_resource_group.aci_rg.name
+  location            = azurerm_resource_group.aci_rg.location
+  ip_address_type     = "public"
+  dns_name_label      = var.dns_name_label
+  os_type             = var.os_type
 
   container {
-      name      = "${var.container_name}"
-      image     = "${var.image_name}"
-      cpu       = "${var.cpu_core_number}"
-      memory    = "${var.memory_size}"
-      port      = "${var.port_number}"
+    name   = var.container_name
+    image  = var.image_name
+    cpu    = var.cpu_core_number
+    memory = var.memory_size
+    port   = var.port_number
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,9 @@ resource "azurerm_container_group" "containergroup" {
     image  = var.image_name
     cpu    = var.cpu_core_number
     memory = var.memory_size
-    port   = var.port_number
+    ports {
+      port     = var.port_number
+      protocol = var.port_protocol
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,46 +1,56 @@
 variable "container_group_name" {
-  default       = "myContGroup"
-  description   = "The name of the container group"
+  type        = string
+  default     = "myContGroup"
+  description = "The name of the container group"
 }
 
 variable "resource_group_name" {
-  default       = "MyContGroup-RG01"
-  description   = "The name of the resource group"
+  type        = string
+  default     = "MyContGroup-RG01"
+  description = "The name of the resource group"
 }
 
 variable "location" {
-  default       = "westus"  
-  description   = "Azure location"
+  type        = string
+  default     = "westus"
+  description = "Azure location"
 }
 
 variable "dns_name_label" {
-  description   = "The DNS label/name for the container groups IP"
+  type        = string
+  description = "The DNS label/name for the container groups IP"
 }
 
 variable "os_type" {
-  description   = "The OS for the container group. Allowed values are Linux and Windows"
+  type        = string
+  description = "The OS for the container group. Allowed values are Linux and Windows"
 }
 
 variable "container_name" {
-  default       = "mycont01"  
-  description   = "The name of the container"
+  type        = string
+  default     = "mycont01"
+  description = "The name of the container"
 }
 
 variable "image_name" {
-  description   = "The container image name"
+  type        = string
+  description = "The container image name"
 }
 
 variable "cpu_core_number" {
-  default       = "0.5"  
-  description   = "The required number of CPU cores of the containers"
+  type        = number
+  default     = 0.5
+  description = "The required number of CPU cores of the containers"
 }
 
 variable "memory_size" {
-  default       = "1.5"  
-  description   = "The required memory of the containers in GB"
+  type        = number
+  default     = 1.5
+  description = "The required memory of the containers in GB"
 }
 
 variable "port_number" {
-  default       = "80"  
-  description   = "A public port for the container"
+  type        = number
+  default     = 80
+  description = "A public port for the container"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,9 @@ variable "port_number" {
   default     = 80
   description = "A public port for the container"
 }
+
+variable "port_protocol" {
+  type        = string
+  default     = "TCP"
+  description = "Protocol used for exposed port (Valid values are TCP or UDP, defaults to TCP) "
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
The module was broken due to usage of deprecated `port` property. This branch uses current `ports` block on `azurerm_container_group` to specify exposed port. 

Additionally, this PR achieves the following

- Use interpolation syntax introduced with Terraform `0.12`
- define types for all variables
- allow consumers to specify protocol for exposed port 